### PR TITLE
fix: Text beyond the container does not wrap automatically

### DIFF
--- a/src/pages/thread/thread.vue
+++ b/src/pages/thread/thread.vue
@@ -406,6 +406,10 @@ const showLoginDialog = ref(false)
         .h5-a {
             color: #1890ff;
         }
+
+        .h5-code {
+            white-space: pre-wrap;
+        }
     }
 
     .content>view {


### PR DESCRIPTION
修复文本超出容器不会自动换行
小程序端white-space默认是pre
h5端默认就是pre-wrap