### PR TITLE
fix: thread views don't increase

### DIFF
--- a/src/pages/index/index.vue
+++ b/src/pages/index/index.vue
@@ -105,9 +105,10 @@ useDidShow(() => {
 // 加载帖子数据
 const isLoading = ref(true)
 const pagination = ref({ page: 1, limit: 20 })
-const threadIndexResponse = computedAsync(async () => {
+const threadIndexResponse = ref()
+computedAsync(async () => {
   const resp = await IndexThread({ page: pagination.value.page, pageSize: pagination.value.limit });
-  return resp.data || [];
+  threadIndexResponse.value = resp.data || [];
 }, undefined, { evaluating: isLoading })
 // 翻页后跳转到顶部
 watch(isLoading, () => {


### PR DESCRIPTION
修复跳转帖子详情页并返回后，首页帖子浏览量不会增加

原来的`threadIndexResponse`是通过`computedAsync`直接返回的，
修改其中的`views_cnt`,Vue好像并不会监听到他的变化，导致页面中的浏览量不更新
用 `ref()`函数来声明可以解决这个问题