### PR TITLE
fix: searchbar text color is white in light theme

### DIFF
--- a/src/pages/search/search.vue
+++ b/src/pages/search/search.vue
@@ -121,7 +121,7 @@ const goThread = (id: number) => {
 .search-page {
     .nut-searchbar {
         .nut-searchbar__search-input {
-            color: var(--page-bg-color);
+            color: #000;
         }
     }
 


### PR DESCRIPTION
修复浅色主题下搜索栏文字颜色为白色,无法看清