### PR TITLE
fix: user groupName tag is abnormal

### DIFF
--- a/src/widgets/tags.vue
+++ b/src/widgets/tags.vue
@@ -2,16 +2,14 @@
   <view class="level-container">
     <nut-tag class="tag" v-if="groupName !== ''" color="#1979ff" plain>{{ groupName }}</nut-tag>
     <!-- tags -->
-    <template v-if="userTags">
-      <nut-tag v-for="tag in userTags" class="tag" :color="tag.color" plain>{{ tag.text }}</nut-tag>
-    </template>
+    <nut-tag v-for="tag in userTags" class="tag" :color="tag.color" plain>{{ tag.text }}</nut-tag>
   </view>
 </template>
 
 <script lang="ts" setup>
 import { UserTags } from '@/api';
 
-defineProps<{
+const { groupName = '', userTags = [] } = defineProps<{
   groupName: string,
   userTags: UserTags[],
 }>()


### PR DESCRIPTION
修复用户组标签显示异常
groupName没有设置默认值,默认不是为空字符串
![微信图片_20240829121550](https://github.com/user-attachments/assets/8f59e78c-60eb-4661-b0b7-eb14147caeee)
