### PR TITLE
feat: tabbar adapter ios

### DIFF
--- a/src/widgets/tabbar.vue
+++ b/src/widgets/tabbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <nut-tabbar v-model="tabs.active" bottom @tab-switch="tabSwitch">
+  <nut-tabbar v-model="tabs.active" bottom @tab-switch="tabSwitch" safe-area-inset-bottom>
     <nut-tabbar-item tab-title="首页" name="index">
       <template #icon>
         <Home></Home>


### PR DESCRIPTION
添加`safe-area-inset-bottom`属性以开启 iphone 系列全面屏底部安全区适配
