### PR TITLE
fix: tabbar icon missing

### DIFF
--- a/config/index.ts
+++ b/config/index.ts
@@ -25,7 +25,9 @@ const config = {
   ],
   defineConstants: {},
   copy: {
-    patterns: [],
+    patterns: [
+      { from: 'src/assets', to: `dist/${process.env.TARO_ENV}/assets` },
+    ],
     options: {},
   },
   framework: "vue3",


### PR DESCRIPTION
tabbar 图标需要手动拷贝到assets目录